### PR TITLE
Add /config command with vim mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Available models:
 - `o4-mini`
 - `codex-mini-latest` (default)
 
+While chatting, use `/config` to view or change settings. Currently only Vim mode
+can be toggled via `/config vim on|off`.
+
 The chat interface provides:
 
 1. An MCP filesystem server (via `npx @modelcontextprotocol/server-filesystem`) for accessing your codebase

--- a/src/oai_coding_agent/console/key_bindings.py
+++ b/src/oai_coding_agent/console/key_bindings.py
@@ -1,9 +1,12 @@
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.defaults import load_key_bindings
+from prompt_toolkit.key_binding.key_bindings import KeyBindingsBase, merge_key_bindings
 from prompt_toolkit.keys import Keys
 
 
-def get_key_bindings() -> KeyBindings:
-    """Return the custom KeyBindings (e.g. Tab behaviour)."""
+def get_key_bindings() -> KeyBindingsBase:
+    """Return default key bindings merged with our custom ones."""
+    default_bindings = load_key_bindings()
     kb = KeyBindings()
 
     @kb.add(Keys.Tab)
@@ -33,4 +36,5 @@ def get_key_bindings() -> KeyBindings:
         """Submit input on Enter"""
         event.current_buffer.validate_and_handle()
 
-    return kb
+    # Merge with default bindings so editing mode changes take effect.
+    return merge_key_bindings([default_bindings, kb])

--- a/src/oai_coding_agent/console/repl.py
+++ b/src/oai_coding_agent/console/repl.py
@@ -20,8 +20,6 @@ async def main(repo_path: Path, model: str, openai_api_key: str) -> None:
     state = UIState()
     clear_terminal()
 
-    register_slash_commands(state)
-
     console.print(
         Panel(
             f"[bold cyan]╭─ OAI CODING AGENT ─╮[/bold cyan]\n\n"
@@ -42,14 +40,20 @@ async def main(repo_path: Path, model: str, openai_api_key: str) -> None:
         auto_suggest=AutoSuggestFromHistory(),
         enable_history_search=True,
         complete_while_typing=True,
-        completer=WordCompleter([f"/{c}" for c in state.slash_commands]),
+        completer=WordCompleter([f"/{c}" for c in []]),
         complete_in_thread=True,
         key_bindings=kb,
         style=Style.from_dict(
             {"prompt": "ansicyan bold", "auto-suggestion": "#888888"}
         ),
         erase_when_done=True,
+        vi_mode=state.config.get("vim_mode", False),
     )
+
+    state.prompt_session = prompt_session
+    register_slash_commands(state)
+    # Update completer with registered commands
+    prompt_session.completer = WordCompleter([f"/{c}" for c in state.slash_commands])
 
     async with AgentSession(
         repo_path=repo_path, model=model, openai_api_key=openai_api_key

--- a/src/oai_coding_agent/console/state.py
+++ b/src/oai_coding_agent/console/state.py
@@ -2,7 +2,9 @@
 UI state container (replaces global messages and slash_commands).
 """
 
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
+
+from prompt_toolkit import PromptSession
 
 
 class UIState:
@@ -11,3 +13,7 @@ class UIState:
     def __init__(self) -> None:
         self.messages: List[dict] = []
         self.slash_commands: Dict[str, Callable[..., bool]] = {}
+        # Configuration options toggled via /config
+        self.config: Dict[str, bool] = {"vim_mode": False}
+        # PromptSession instance for runtime config changes
+        self.prompt_session: Optional[PromptSession] = None

--- a/tests/test_slash_commands.py
+++ b/tests/test_slash_commands.py
@@ -25,7 +25,7 @@ def record_console(monkeypatch):
 def test_register_slash_commands_populates_commands():
     state = UIState()
     register_slash_commands(state)
-    expected = {"help", "clear", "exit", "quit", "version"}
+    expected = {"help", "clear", "exit", "quit", "version", "config"}
     assert expected.issubset(set(state.slash_commands.keys()))
 
 
@@ -64,3 +64,23 @@ def test_handle_unknown_command_appends_unknown(record_console):
     assert cont is True
     msg = state.messages[-1]
     assert "Unknown command: /nonexistent" in msg["content"]
+
+
+def test_config_command_lists_options(record_console):
+    state = UIState()
+    register_slash_commands(state)
+    cont = handle_slash_command(state, "/config")
+    assert cont is True
+    msg = state.messages[-1]
+    assert "Current configuration:" in msg["content"]
+    assert "vim_mode" in msg["content"]
+
+
+def test_config_vim_toggle(record_console):
+    state = UIState()
+    register_slash_commands(state)
+    cont = handle_slash_command(state, "/config vim on")
+    assert cont is True
+    assert state.config["vim_mode"] is True
+    msg = state.messages[-1]
+    assert "Vim mode enabled" in msg["content"]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -9,3 +9,5 @@ def test_ui_state_initializes_empty():
     assert state.messages == []
     assert isinstance(state.slash_commands, dict)
     assert state.slash_commands == {}
+    assert state.config == {"vim_mode": False}
+    assert state.prompt_session is None


### PR DESCRIPTION
## Summary
- add vim mode configuration support in UIState
- implement `/config` slash command to toggle vim mode
- set vi_mode in PromptSession based on config
- document new command in README
- update tests for new config behavior
- merge default prompt-toolkit key bindings so editing mode updates work at runtime

## Testing
- `uv run pytest -q`
