### PR TITLE
docs: update documentation for preflight checks

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,9 +2,11 @@
 flowchart TD
   subgraph CLI
     A[oai CLI entrypoint] -->|flags| B[main command]
+    B --> P[Preflight checks (Git, Node.js, Docker)]
   end
-  B -->|--prompt / -p| H[Headless mode]
-  B -->|interactive| C[prompt-toolkit REPL]
+  P -->|success| H[Headless mode]
+  P -->|success| C[prompt-toolkit REPL]
+  P -->|failure| G[Print errors & exit]
   H --> D[Agent backend]
   C -->|user input| D
   D -->|assistant messages| E[Rich Markdown renderer]

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -1,0 +1,36 @@
+# Preflight Checks
+
+The `oai` CLI now performs a set of *preflight checks* before running commands to ensure the environment meets the requirements. These checks are always run and **cannot be skipped**.
+
+## What is checked
+
+- **Git worktree**: Verifies that the current Git worktree is clean and on a supported branch.
+- **Node.js**: Ensures Node.js is installed and meets the minimum required version.
+- **Docker**: Checks that Docker is installed, reachable, and running.
+
+## Failure behavior
+
+If any preflight check fails, the CLI:
+
+1. Prints error messages describing the failures.
+2. Exits immediately with a non-zero status code.
+
+## Logging
+
+The tool versions and check results are logged to:
+
+```
+~/.oai_coding_agent/agent.log
+```
+
+## No skip flags
+
+There are no flags or options to skip the preflight checks. This ensures that the agent always runs in a validated environment.
+
+## Adding future checks
+
+To extend the preflight process:
+
+1. Add the new check in the preflight implementation (e.g., `oai_coding_agent.preflight`).
+2. Document the new check in `docs/preflight.md`.
+3. Update the CLI flowchart in `docs/cli.md` to reflect the added step.


### PR DESCRIPTION
## Summary

Update project documentation to reflect the new preflight-check behavior introduced in Issue #8. This updates the CLI flowchart in `docs/cli.md` and adds detailed documentation in `docs/preflight.md`.

## Implementation Details

- Replaced the Mermaid flowchart in `docs/cli.md` to insert a dedicated Preflight checks node between the main command and headless/interactive paths.
- Added `docs/preflight.md` with sections covering which checks run, failure behavior, logging location, non-skippable nature, and guidelines for adding future checks.
- Ensured alignment with the project’s AGENTS.md documentation requirements.

## Assumptions Made

- The default Git branch is `main`.
- Indentation style for the flowchart follows existing patterns in `docs/cli.md`.
- No Markdown linting rules required explicit formatting in this project.

## Testing

- Verified that existing tests pass (`uv run pytest`).
- No changes to application code; only documentation files were modified.

## Considerations / Alternatives

- Could have updated the README or other higher-level docs to reference the preflight steps, but chose to centralize this documentation under `docs/preflight.md`.
- Inline documentation in the code was considered, but external documentation was deemed more accessible for users.