### PR TITLE
Fix mypy errors and improve prompt handling

### DIFF
--- a/src/oai_coding_agent/agent.py
+++ b/src/oai_coding_agent/agent.py
@@ -132,12 +132,13 @@ class _AgentSession:
             ref = os.getenv("GITHUB_REF", "")
             branch_name = ref.rsplit("/", 1)[-1] if "/" in ref else ref
 
-        return template.render(
+        rendered: str = template.render(
             repo_path=str(self.repo_path),
             mode=self.mode,
             github_repository=github_repo,
             branch_name=branch_name,
         )
+        return rendered
 
     def _map_sdk_event(self, event: Any) -> Optional[Dict[str, Any]]:
         evt_type = getattr(event, "type", None)

--- a/src/oai_coding_agent/cli.py
+++ b/src/oai_coding_agent/cli.py
@@ -23,7 +23,7 @@ console = Console()
 app = typer.Typer(rich_markup_mode=None)
 
 
-@app.command()
+@app.command()  # type: ignore[misc]
 def main(
     openai_api_key: Annotated[
         str, typer.Option(envvar="OPENAI_API_KEY", help="OpenAI API key")
@@ -74,6 +74,9 @@ def main(
     if prompt:
         # Force async mode for one-off prompt runs
         mode_value = ModeChoice.async_.value
+        prompt_text = (
+            Path(prompt).read_text() if Path(prompt).is_file() else prompt
+        )
         logger.info(f"Running prompt in headless (async): {prompt}")
         try:
             asyncio.run(
@@ -83,7 +86,7 @@ def main(
                     cfg.openai_api_key,
                     cfg.github_personal_access_token,
                     mode_value,
-                    prompt,
+                    prompt_text,
                 )
             )
         except KeyboardInterrupt:

--- a/src/oai_coding_agent/console/key_bindings.py
+++ b/src/oai_coding_agent/console/key_bindings.py
@@ -1,4 +1,5 @@
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 from prompt_toolkit.keys import Keys
 
 
@@ -6,8 +7,8 @@ def get_key_bindings() -> KeyBindings:
     """Return the custom KeyBindings (e.g. Tab behaviour)."""
     kb = KeyBindings()
 
-    @kb.add(Keys.Tab)
-    def _(event):
+    @kb.add(Keys.Tab)  # type: ignore[misc]
+    def _(event: KeyPressEvent) -> None:
         buffer = event.current_buffer
         suggestion = buffer.suggestion
         if suggestion:
@@ -16,20 +17,20 @@ def get_key_bindings() -> KeyBindings:
             buffer.complete_next()
 
     # Support Shift+Enter (mapped to Ctrl+J in your terminal) for newline without submission.
-    @kb.add("c-j", eager=True)
-    def _(event):
+    @kb.add("c-j", eager=True)  # type: ignore[misc]
+    def _(event: KeyPressEvent) -> None:
         """Insert newline on Ctrl+J (recommended Shift+Enter mapping in terminal)."""
         event.current_buffer.insert_text("\n")
 
     # Support Alt+Enter for newline without submission.
-    @kb.add(Keys.Escape, Keys.Enter, eager=True)
-    def _(event):
+    @kb.add(Keys.Escape, Keys.Enter, eager=True)  # type: ignore[misc]
+    def _(event: KeyPressEvent) -> None:
         """Insert newline on Alt+Enter."""
         event.current_buffer.insert_text("\n")
 
     # Enter submits input
-    @kb.add(Keys.Enter, eager=True)
-    def _(event):
+    @kb.add(Keys.Enter, eager=True)  # type: ignore[misc]
+    def _(event: KeyPressEvent) -> None:
         """Submit input on Enter"""
         event.current_buffer.validate_and_handle()
 

--- a/src/oai_coding_agent/console/rendering.py
+++ b/src/oai_coding_agent/console/rendering.py
@@ -1,20 +1,22 @@
 import os
+from typing import Any, Iterable
 
 from rich.console import Console
 from rich.markdown import Heading, Markdown
-from rich.panel import Panel
+
+from .state import Message
 
 
 # Classes to override the default Markdown renderer
-class PlainHeading(Heading):
+class PlainHeading(Heading):  # type: ignore[misc]
     """Left-aligned, no panel."""
 
-    def __rich_console__(self, console, options):
+    def __rich_console__(self, console: Console, options: Any) -> Iterable[Any]:
         self.text.justify = "left"
         yield self.text
 
 
-class PlainMarkdown(Markdown):
+class PlainMarkdown(Markdown):  # type: ignore[misc]
     elements = Markdown.elements.copy()
     elements["heading_open"] = PlainHeading
 
@@ -31,7 +33,7 @@ def clear_terminal() -> None:
     os.system("cls" if os.name == "nt" else "clear")
 
 
-def render_message(msg: dict) -> None:
+def render_message(msg: Message) -> None:
     """Render a single message via Rich."""
     role = msg.get("role")
     content = msg.get("content", "")

--- a/src/oai_coding_agent/console/repl.py
+++ b/src/oai_coding_agent/console/repl.py
@@ -9,7 +9,9 @@ from prompt_toolkit.styles import Style
 from rich.panel import Panel
 
 from ..agent import AgentSession
-from .state import UIState
+from typing import cast
+
+from .state import Message, UIState
 from .rendering import console, clear_terminal, render_message
 from .slash_commands import register_slash_commands, handle_slash_command
 from .key_bindings import get_key_bindings
@@ -83,14 +85,14 @@ async def main(
                     continue_loop = handle_slash_command(state, user_input)
                     continue
 
-                user_msg = {"role": "user", "content": user_input}
+                user_msg: Message = {"role": "user", "content": user_input}
                 state.messages.append(user_msg)
                 console.print(f"[dim]› {user_input}[/dim]\n")
 
                 ui_stream, result = await session_agent.run_step(user_input, prev_id)
                 async for msg in ui_stream:
-                    state.messages.append(msg)
-                    render_message(msg)
+                    state.messages.append(cast(Message, msg))
+                    render_message(cast(Message, msg))
 
                 prev_id = result.last_response_id
 

--- a/src/oai_coding_agent/console/slash_commands.py
+++ b/src/oai_coding_agent/console/slash_commands.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-from .state import UIState
+from .state import Message, UIState
 from .rendering import clear_terminal, render_message
 
 
@@ -14,7 +14,7 @@ def register_slash_commands(state: UIState) -> None:
         for cmd, func in state.slash_commands.items():
             doc = func.__doc__ or "No description available"
             help_text += f"/{cmd} - {doc}\n"
-        msg = {"role": "system", "content": help_text}
+        msg: Message = {"role": "system", "content": help_text}
         state.messages.append(msg)
         render_message(msg)
         return True
@@ -22,7 +22,7 @@ def register_slash_commands(state: UIState) -> None:
     def cmd_clear(args: str = "") -> bool:
         """Clear the chat history."""
         state.messages.clear()
-        msg = {"role": "system", "content": "Chat history has been cleared."}
+        msg: Message = {"role": "system", "content": "Chat history has been cleared."}
         state.messages.append(msg)
         clear_terminal()
         render_message(msg)
@@ -34,7 +34,7 @@ def register_slash_commands(state: UIState) -> None:
 
     def cmd_version(args: str = "") -> bool:
         """Show version information."""
-        msg = {
+        msg: Message = {
             "role": "system",
             "content": "CLI Chat Version: 0.1.0\nBuilt with Rich and prompt-toolkit",
         }
@@ -61,12 +61,12 @@ def handle_slash_command(state: UIState, text: str) -> bool:
         try:
             return state.slash_commands[cmd](args)
         except Exception as e:
-            msg = {"role": "system", "content": f"Error executing /{cmd}: {e}"}
-            state.messages.append(msg)
-            render_message(msg)
+            error_msg: Message = {"role": "system", "content": f"Error executing /{cmd}: {e}"}
+            state.messages.append(error_msg)
+            render_message(error_msg)
             return True
     else:
-        msg = {
+        msg: Message = {
             "role": "system",
             "content": f"Unknown command: /{cmd}\nType /help to see available commands.",
         }

--- a/src/oai_coding_agent/console/state.py
+++ b/src/oai_coding_agent/console/state.py
@@ -2,12 +2,19 @@
 UI state container (replaces global messages and slash_commands).
 """
 
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, TypedDict
+
+
+class Message(TypedDict):
+    """Simple message container used by the UI state."""
+
+    role: str
+    content: str
 
 
 class UIState:
     """Holds messages and registered slash commands for the console interface."""
 
     def __init__(self) -> None:
-        self.messages: List[dict] = []
+        self.messages: List[Message] = []
         self.slash_commands: Dict[str, Callable[..., bool]] = {}

--- a/src/oai_coding_agent/headless.py
+++ b/src/oai_coding_agent/headless.py
@@ -5,7 +5,10 @@ Headless (non-interactive) mode for running a single prompt asynchronously.
 import asyncio
 from pathlib import Path
 
+from typing import cast
+
 from .agent import AgentSession
+from .console.state import Message
 from .console.rendering import console as rich_console, render_message
 
 
@@ -38,4 +41,4 @@ async def headless_main(
     ) as session_agent:
         ui_stream, _ = await session_agent.run_step(prompt)
         async for msg in ui_stream:
-            render_message(msg)
+            render_message(cast(Message, msg))

--- a/src/oai_coding_agent/mcp_servers.py
+++ b/src/oai_coding_agent/mcp_servers.py
@@ -6,7 +6,7 @@ import logging
 import os
 from contextlib import AsyncExitStack
 from pathlib import Path
-from typing import List
+from typing import Any, List
 
 from agents.mcp import MCPServer, MCPServerStdio
 from mcp.client.stdio import stdio_client
@@ -43,10 +43,10 @@ ALLOWED_CLI_COMMANDS = [
 ALLOWED_CLI_FLAGS = ["all"]
 
 
-class QuietMCPServerStdio(MCPServerStdio):
+class QuietMCPServerStdio(MCPServerStdio):  # type: ignore[misc]
     """Variant of MCPServerStdio that silences child-process stderr."""
 
-    def create_streams(self):
+    def create_streams(self) -> Any:
         return stdio_client(self.params, errlog=open(os.devnull, "w"))
 
 

--- a/src/oai_coding_agent/mcp_tool_selector.py
+++ b/src/oai_coding_agent/mcp_tool_selector.py
@@ -33,7 +33,6 @@ def _filter_tools_for_mode(
         # Read-only commands only in plan mode
         if mode == "plan":
             readonly_allowed = {
-                "create_issue",
                 "get_issue",
                 "get_issue_comments",
                 "list_issues",


### PR DESCRIPTION
## Summary
- introduce `Message` TypedDict and use it across UI modules
- clean up key bindings and rendering type hints
- add prompt file support in CLI
- restrict GitHub tools in plan mode
- silence MCP server type noise

## Testing
- `mypy src`
- `uv run pytest`