### PR TITLE
Simplify Agent.run and remove previous_response_id parameter

### DIFF
--- a/src/oai_coding_agent/agent/agent.py
+++ b/src/oai_coding_agent/agent/agent.py
@@ -14,7 +14,6 @@ from agents import (
 from agents import (
     ModelSettings,
     Runner,
-    RunResultStreaming,
     gen_trace_id,
     trace,
 )
@@ -47,10 +46,7 @@ class AgentProtocol(Protocol):
     async def run(
         self,
         user_input: str,
-    ) -> tuple[
-        AsyncIterator[ToolCallEvent | ReasoningEvent | MessageOutputEvent],
-        RunResultStreaming,
-    ]: ...
+    ) -> AsyncIterator[ToolCallEvent | ReasoningEvent | MessageOutputEvent]: ...
 
 
 class Agent:
@@ -108,13 +104,9 @@ class Agent:
     async def run(
         self,
         user_input: str,
-    ) -> tuple[
-        AsyncIterator[ToolCallEvent | ReasoningEvent | MessageOutputEvent],
-        RunResultStreaming,
-    ]:
+    ) -> AsyncIterator[ToolCallEvent | ReasoningEvent | MessageOutputEvent]:
         """
-        Send one user message to the agent and return an async iterator of agent events
-        plus the underlying RunResultStreaming.
+        Send one user message to the agent and return an async iterator of agent events.
         """
         if self._sdk_agent is None:
             raise RuntimeError("Agent not initialized. Use async with context manager.")
@@ -138,4 +130,4 @@ class Agent:
 
         # Store the last-response ID so subsequent calls continue the dialogue
         self._previous_response_id = result.last_response_id
-        return _map_events(), result
+        return _map_events()

--- a/src/oai_coding_agent/console/console.py
+++ b/src/oai_coding_agent/console/console.py
@@ -92,7 +92,6 @@ class ReplConsole:
         )
 
         async with self.agent:
-            prev_id = None
             continue_loop = True
             while continue_loop:
                 try:
@@ -112,12 +111,10 @@ class ReplConsole:
 
                     console.print(f"[dim]› {user_input}[/dim]\n")
 
-                    event_stream, result = await self.agent.run(user_input, prev_id)
+                    event_stream, result = await self.agent.run(user_input)
                     async for event in event_stream:
                         ui_msg = map_event_to_ui_message(event)
                         render_message(ui_msg)
-
-                    prev_id = result.last_response_id
 
                 except (KeyboardInterrupt, EOFError):
                     continue_loop = False

--- a/src/oai_coding_agent/console/console.py
+++ b/src/oai_coding_agent/console/console.py
@@ -41,7 +41,7 @@ class HeadlessConsole:
 
         console.print(f"[bold cyan]Prompt:[/bold cyan] {self.agent.config.prompt}")
         async with self.agent:
-            event_stream, _ = await self.agent.run(self.agent.config.prompt)
+            event_stream = await self.agent.run(self.agent.config.prompt)
             async for event in event_stream:
                 ui_msg = map_event_to_ui_message(event)
                 if ui_msg:
@@ -111,7 +111,7 @@ class ReplConsole:
 
                     console.print(f"[dim]› {user_input}[/dim]\n")
 
-                    event_stream, result = await self.agent.run(user_input)
+                    event_stream = await self.agent.run(user_input)
                     async for event in event_stream:
                         ui_msg = map_event_to_ui_message(event)
                         render_message(ui_msg)

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, AsyncGenerator, cast
+from typing import Any, AsyncGenerator, Optional, cast
 from unittest.mock import Mock
 
 import pytest
@@ -106,6 +106,8 @@ async def test_run_streams_and_returns(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeResult:
         def __init__(self, evts: list[Any]) -> None:
             self._events = evts
+            # expose last_response_id so Agent.run can store it
+            self.last_response_id: Optional[str] = None
 
         def stream_events(self) -> AsyncGenerator[Any, None]:
             async def gen() -> AsyncGenerator[Any, None]:
@@ -115,8 +117,6 @@ async def test_run_streams_and_returns(monkeypatch: pytest.MonkeyPatch) -> None:
             return gen()
 
     fake_result = FakeResult(events)
-    # Provide a last_response_id so Agent.run can store it without error
-    fake_result.last_response_id = None
 
     # Monkeypatch Runner.run_streamed
     monkeypatch.setattr(

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -135,9 +135,7 @@ async def test_run_streams_and_returns(monkeypatch: pytest.MonkeyPatch) -> None:
     agent = Agent(config, max_turns=1)
     agent._sdk_agent = cast(SDKAgent, object())
 
-    event_stream, returned = await agent.run("input text")
-    # Should return the underlying result as is
-    assert returned is fake_result  # type: ignore[comparison-overlap]
+    event_stream = await agent.run("input text")
     # Verify we can iterate the mapped events from the stream
     collected = []
     async for event in event_stream:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterator, Optional
+from typing import Any, AsyncIterator
 from unittest.mock import Mock
 
 from oai_coding_agent.agent import AgentProtocol
@@ -11,7 +11,7 @@ class MockAgent:
     def __init__(self, config: RuntimeConfig):
         self.config = config
         self.run_called = False
-        self.run_args: list[tuple[str, Optional[str]]] = []
+        self.run_args: list[str] = []
 
     async def __aenter__(self) -> "MockAgent":
         return self
@@ -22,18 +22,15 @@ class MockAgent:
     async def run(
         self,
         user_input: str,
-        previous_response_id: Optional[str] = None,
-    ) -> tuple[AsyncIterator[Any], Any]:
+    ) -> AsyncIterator[Any]:
         self.run_called = True
-        self.run_args.append((user_input, previous_response_id))
+        self.run_args.append(user_input)
 
         async def empty_stream() -> AsyncIterator[Any]:
             if False:
                 yield
 
-        result = Mock()
-        result.last_response_id = None
-        return empty_stream(), result
+        return empty_stream()
 
 
 class MockConsole:


### PR DESCRIPTION
Remove previous_response_id param and simplify Agent.run signature

- Deleted previous_response_id argument from Agent.run signature and AgentProtocol interface
- Added internal `_previous_response_id` field in Agent to manage conversation context
- Updated Runner.run_streamed call to always use the internal last_response_id
- Console no longer manages prev_id; updated ReplConsole to call `agent.run(user_input)` directly
- Adjusted tests to provide `FakeResult.last_response_id` and drop passing previous_response_id in tests
- Fixed mypy in `test_agent.py` by declaring `FakeResult.last_response_id`
- Simplified Agent.run signature to return only the event iterator, removing exposure of RunResultStreaming
- Updated MockAgent in `tests/conftest.py` and `test_agent.py` to expect new signature
- Removed tests for returned result value in mapping tests

This pull request was created with oai-coding-agent