### PR TITLE
Add git hook to add Co-Authored trailer to commits 

### DIFF
--- a/src/oai_coding_agent/agent/mcp_servers.py
+++ b/src/oai_coding_agent/agent/mcp_servers.py
@@ -94,6 +94,8 @@ async def start_mcp_servers(
                     "ALLOWED_FLAGS": ",".join(ALLOWED_CLI_FLAGS),
                     "ALLOW_SHELL_OPERATORS": "true",
                     "COMMAND_TIMEOUT": "120",
+                    # set OAI_AGENT so commit-msg hook sees it
+                    "OAI_AGENT": "true",
                 },
             },
             client_session_timeout_seconds=120,
@@ -112,6 +114,8 @@ async def start_mcp_servers(
             name="mcp-server-git",
             params={
                 "command": "mcp-server-git",
+                # set OAI_AGENT so commit-msg hook sees it
+                "env": {"OAI_AGENT": "true"},
             },
             client_session_timeout_seconds=120,
             cache_tools_list=True,

--- a/src/oai_coding_agent/templates/commit_msg_hook.jinja2
+++ b/src/oai_coding_agent/templates/commit_msg_hook.jinja2
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# commit-msg hook: append Co-Authored-By stanza when OAI_AGENT is set
+
+if [ -n "$OAI_AGENT" ]; then
+  printf "\n🤖 Generated with oai-coding-agent\nCo-Authored-By: OAI <noreply@oai-coding-agent.com>\n" >> "$1"
+fi

--- a/tests/test_install_commit_msg_hook.py
+++ b/tests/test_install_commit_msg_hook.py
@@ -1,0 +1,65 @@
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+from oai_coding_agent.preflight import install_commit_msg_hook
+
+
+def test_install_commit_msg_hook_creates_hook_and_configures_git(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    install_commit_msg_hook should write the commit-msg hook from the template,
+    make it executable, and call git config to set core.hooksPath.
+    """
+    # Point XDG_CONFIG_HOME to a temporary location
+    config_home = tmp_path / "config_home"
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config_home))
+
+    # Create a fake repo directory
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # Capture subprocess.run calls
+    runs = []
+
+    def fake_run(
+        cmd: list[str],
+        cwd: Path | None = None,
+        check: bool = False,
+    ) -> None:
+        runs.append((cmd, cwd, check))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # Run the installer
+    install_commit_msg_hook(repo)
+
+    # Check that the hook file was created in the XDG_CONFIG_HOME path
+    hooks_dir = config_home / "oai_coding_agent" / "hooks"
+    hook_file = hooks_dir / "commit-msg"
+    assert hook_file.exists(), "Expected commit-msg hook file to be created"
+
+    # Verify the content matches the Jinja2 template rendering
+    env = Environment(
+        loader=PackageLoader("oai_coding_agent", "templates"),
+        autoescape=select_autoescape([]),
+    )
+    expected_script = env.get_template("commit_msg_hook.jinja2").render()
+    actual_script = hook_file.read_text(encoding="utf-8")
+    assert actual_script == expected_script
+
+    # Verify file is executable (user executable bit should be set)
+    mode = stat.S_IMODE(hook_file.stat().st_mode)
+    assert mode & stat.S_IXUSR, "Expected commit-msg hook to be executable"
+
+    # Verify subprocess.run was called once with git config core.hooksPath
+    assert len(runs) == 1
+    cmd, cwd, check_flag = runs[0]
+    assert cmd == ["git", "config", "--local", "core.hooksPath", str(hooks_dir)]
+    assert cwd == repo
+    assert check_flag is False

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -35,6 +35,9 @@ def test_run_preflight_success(
             return subprocess.CompletedProcess(
                 cmd, 0, stdout="Docker version 20.10.7, build abcdef1\n"
             )
+        # Git config hook-path install
+        if cmd[:3] == ["git", "config", "--local"]:
+            return subprocess.CompletedProcess(cmd, 0)
         pytest.fail(f"Unexpected command: {cmd}")
 
     def fake_check_output(


### PR DESCRIPTION
- Writes a git hook to `~/.config/oai-coding-agent/` and installs it into user's repo on start up 
- Hook appends this to commit messages when `OAI_AGENT=true` 
```
🤖 Generated with oai-coding-agent 
Co-Authored By: OAI <noreply@oai-coding-agent.com>
```

<img width="623" alt="Screenshot 2025-06-03 at 9 05 57 PM" src="https://github.com/user-attachments/assets/25e8588f-4508-4f48-a363-33aeec47f971" />

Example commit [here](https://github.com/MattMorgis/oai-coding-agent/pull/35/commits/f1a52da4dadeeaa50043f4990b695f2fd650d59b) 

---
_This pull request was created with oai‑coding‑agent_