### PR TITLE
Fix agent workflow with backticks in input

### DIFF
--- a/.github/workflows/oai-agent.yml
+++ b/.github/workflows/oai-agent.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run OAI coding agent in headless mode
         env:
-          RICH_FORCE_TERMINAL: "1"
+          RICH_FORCE_TERMINAL: "1" # these provide pretty logs in GHA
           TTY_COMPATIBLE: "1"
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -70,4 +70,11 @@ jobs:
         run: |
           uv sync
           source .venv/bin/activate
-          echo "${{ github.event.issue.body }}" | oai --prompt -
+          oai --prompt - << 'PROMPT_END'
+          Complete the following GitHub issue:
+          Repository: ${{ github.event.repository.html_url }}
+          Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}
+
+          Body:
+          ${{ github.event.issue.body }}
+          PROMPT_END


### PR DESCRIPTION
When an issue like #56 contained backticks like `uv run pre-commit`, `echo` was not properly escaping those and they were being executed. 

This "here doc" approach will properly escape. I added some more context while at it and renamed the file, I didn't like `issue` in the file name 