### PR TITLE
feat: set gpt-5 as default model and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ oai -p "tell me what you can do in 2-3 sentences"
 
 ## Overview
 
-This agent is built on OpenAI's codex-mini model and supports three distinct modes that enable a progressive trust-building journey:
+This agent uses OpenAI models (default: gpt-5) and supports three distinct modes that enable a progressive trust-building journey:
 
 1. **Default Mode** - Interactive agent that checks in when decisions are needed
 2. **Async Mode** - Fully autonomous agent that completes tasks independently
@@ -128,7 +128,7 @@ cd ../agent-2 && oai --mode async --prompt "Add API rate limiting"
 
 - `--version, -v` — Show the version and exit
 
-- `--model, -m <model>` — OpenAI model (default: `codex-mini-latest`)
+- `--model, -m <model>` — OpenAI model (default: `gpt-5`)
 - `--repo-path <path>` — Target repository (default: current directory)
 - `--prompt, -p <text | ->` — Headless mode prompt (`-` for stdin)
 

--- a/src/oai_coding_agent/cli.py
+++ b/src/oai_coding_agent/cli.py
@@ -110,7 +110,7 @@ def main(
     model: Annotated[
         ModelChoice,
         typer.Option("--model", "-m", help="OpenAI model to use"),
-    ] = ModelChoice.codex_mini_latest,
+    ] = ModelChoice.gpt_5,
     mode: Annotated[
         ModeChoice,
         typer.Option(

--- a/src/oai_coding_agent/runtime_config.py
+++ b/src/oai_coding_agent/runtime_config.py
@@ -67,6 +67,8 @@ def load_envs(env_file: Optional[str] = None) -> None:
 class ModelChoice(str, Enum):
     """Supported OpenAI model choices."""
 
+    gpt_5 = "gpt-5"
+    gpt_5_mini = "gpt-5-mini"
     codex_mini_latest = "codex-mini-latest"
     o3 = "o3"
     o3_pro = "o3-pro"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -127,7 +127,7 @@ def test_cli_uses_environment_defaults(
 
     agent = mock_agent_factory.agent
     assert agent.config.repo_path == tmp_path
-    assert agent.config.model == ModelChoice.codex_mini_latest
+    assert agent.config.model == ModelChoice.gpt_5
     assert agent.config.openai_api_key == "ENVKEY"
     assert agent.config.openai_base_url == "ENVURL"
     assert agent.config.mode == ModeChoice.default
@@ -153,7 +153,7 @@ def test_cli_uses_cwd_as_default_repo_path(
 
     agent = mock_agent_factory.agent
     assert agent.config.repo_path == expected_cwd
-    assert agent.config.model == ModelChoice.codex_mini_latest
+    assert agent.config.model == ModelChoice.gpt_5
     assert agent.config.openai_api_key == "ENVKEY"
     assert agent.config.openai_base_url is None
     assert agent.config.mode == ModeChoice.default
@@ -179,7 +179,7 @@ def test_cli_prompt_invokes_headless_main(
 
     agent = mock_agent_factory.agent
     assert agent.config.repo_path == tmp_path
-    assert agent.config.model == ModelChoice.codex_mini_latest
+    assert agent.config.model == ModelChoice.gpt_5
     assert agent.config.openai_api_key == "ENVKEY"
     assert agent.config.openai_base_url is None
     assert agent.config.mode == ModeChoice.async_
@@ -207,7 +207,7 @@ def test_cli_prompt_stdin_invokes_headless_main(
 
     agent = mock_agent_factory.agent
     assert agent.config.repo_path == tmp_path
-    assert agent.config.model == ModelChoice.codex_mini_latest
+    assert agent.config.model == ModelChoice.gpt_5
     assert agent.config.openai_api_key == "ENVKEY"
     assert agent.config.openai_base_url is None
     assert agent.config.mode == ModeChoice.async_

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -18,7 +18,10 @@ from oai_coding_agent.xdg import get_config_dir, get_data_dir
 @pytest.mark.parametrize(
     "enum_class,expected_values",
     [
-        (ModelChoice, {"codex-mini-latest", "o3", "o4-mini", "o3-pro"}),
+        (
+            ModelChoice,
+            {"codex-mini-latest", "o3", "o4-mini", "o3-pro", "gpt-5", "gpt-5-mini"},
+        ),
         (ModeChoice, {"default", "async", "plan"}),
     ],
 )


### PR DESCRIPTION
Summary
- Set default model to gpt-5 in CLI (ModelChoice and cli default)
- Updated README to reflect gpt-5 as the default model
- Left unrelated local changes uncommitted to keep this PR focused

Why
- Aligns docs and defaults with current model availability and guidance

Testing
- Ran pre-commit hooks for README (passed/skipped appropriately)
- Ran test suite: 153 passed, 1 skipped

Usage
- No breaking changes to CLI flags; users can still override with --model
- OPENAI_API_KEY remains the only required env var (OPENAI_BASE_URL optional)

Notes
- Base: main
- Head: add-gpt-5